### PR TITLE
Added the "RNTimeZoneModule" to fetch IANA timezone names natively from iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ I added an example of using [reassure](https://github.com/callstack/reassure) to
 I updated the app to React Native v0.75.3.
 
 I added react-native-dev-settings support (required to integrate with React Native Debugger)
+
+### September 16th, 2024
+
+I added the "RNTimeZoneModule" to fetch IANA timezone names natively from iOS and Android

--- a/Sandbox/App.tsx
+++ b/Sandbox/App.tsx
@@ -9,7 +9,7 @@
  */
 
 import {Icon} from '@rneui/themed';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {
   SafeAreaView,
   StatusBar,
@@ -27,6 +27,7 @@ import 'react-native-devsettings';
 import {Colors, Header} from 'react-native/Libraries/NewAppScreen';
 import {MyTextInput} from './MyTextInput';
 import {NotificationsManager} from './NotificationsManager';
+import getTimeZone from './TimeZoneModule';
 
 const Section: React.FC<{
   title: string;
@@ -59,6 +60,7 @@ const Section: React.FC<{
 
 const App = () => {
   const isDarkMode = useColorScheme() === 'dark';
+  const [timeZone, setTimeZone] = useState('');
 
   const backgroundStyle = {
     backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
@@ -74,6 +76,14 @@ const App = () => {
   const refInput2 = React.useRef<TextInput>(null!);
   const refInput3 = React.useRef<TextInput>(null!);
 
+  useEffect(() => {
+    const fetchTimeZone = async () => {
+      const tz = await getTimeZone();
+      setTimeZone(tz);
+    };
+    fetchTimeZone();
+  }, []);
+
   return (
     <SafeAreaView style={backgroundStyle}>
       <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
@@ -86,6 +96,11 @@ const App = () => {
           style={{
             backgroundColor: isDarkMode ? Colors.black : Colors.white,
           }}>
+          <Text
+            style={
+              styles.timezone
+            }>{`IANA timezone string: "${timeZone}"`}</Text>
+
           <Section title="Next key test">
             Use the Next key to move thru these three fields
           </Section>
@@ -137,6 +152,11 @@ const styles = StyleSheet.create({
   },
   highlight: {
     fontWeight: '700',
+  },
+  timezone: {
+    fontWeight: 'bold',
+    marginTop: 8,
+    marginLeft: 8,
   },
   inputWrapper: {
     marginRight: 20,

--- a/Sandbox/TimeZoneModule.js
+++ b/Sandbox/TimeZoneModule.js
@@ -1,0 +1,15 @@
+import {NativeModules} from 'react-native';
+
+const {RNTimeZoneModule} = NativeModules;
+
+const getTimeZone = async () => {
+  try {
+    const timeZone = await RNTimeZoneModule.getTimeZone();
+    return timeZone;
+  } catch (error) {
+    console.error('Failed to get timezone', error);
+    return null;
+  }
+};
+
+export default getTimeZone;

--- a/Sandbox/android/app/src/main/java/com/sandbox/MainApplication.kt
+++ b/Sandbox/android/app/src/main/java/com/sandbox/MainApplication.kt
@@ -11,15 +11,18 @@ import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.soloader.SoLoader
 
+import com.sandbox.RNTimeZonePackage
+
 class MainApplication : Application(), ReactApplication {
 
   override val reactNativeHost: ReactNativeHost =
       object : DefaultReactNativeHost(this) {
         override fun getPackages(): List<ReactPackage> =
-            PackageList(this).packages.apply {
-              // Packages that cannot be autolinked yet can be added manually here, for example:
-              // add(MyReactNativePackage())
-            }
+          PackageList(this).packages.apply {
+            // Packages that cannot be autolinked yet can be added manually here, for example:
+            // add(MyReactNativePackage())
+            add(RNTimeZonePackage())
+        }
 
         override fun getJSMainModuleName(): String = "index"
 

--- a/Sandbox/android/app/src/main/java/com/sandbox/RNTimeZoneModule.java
+++ b/Sandbox/android/app/src/main/java/com/sandbox/RNTimeZoneModule.java
@@ -1,0 +1,37 @@
+package com.sandbox;
+
+import android.os.Build;
+import android.provider.Settings;
+import android.content.Context;
+import java.util.TimeZone;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Promise;
+
+public class RNTimeZoneModule extends ReactContextBaseJavaModule {
+
+    private final ReactApplicationContext reactContext;
+
+    public RNTimeZoneModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        this.reactContext = reactContext;
+    }
+
+    @Override
+    public String getName() {
+        return "RNTimeZoneModule";
+    }
+
+    @ReactMethod
+    public void getTimeZone(Promise promise) {
+        try {
+            TimeZone tz = TimeZone.getDefault();
+            String timeZoneName = tz.getID(); // Get the IANA timezone name like "America/New_York"
+            promise.resolve(timeZoneName);
+        } catch (Exception e) {
+            promise.reject("timezone_error", "Could not retrieve timezone");
+        }
+    }
+}

--- a/Sandbox/android/app/src/main/java/com/sandbox/RNTimeZonePackage.kt
+++ b/Sandbox/android/app/src/main/java/com/sandbox/RNTimeZonePackage.kt
@@ -1,0 +1,19 @@
+package com.sandbox
+
+import android.view.View
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ReactShadowNode
+import com.facebook.react.uimanager.ViewManager
+
+class RNTimeZonePackage : ReactPackage {
+
+    override fun createViewManagers(
+        reactContext: ReactApplicationContext
+    ): MutableList<ViewManager<View, ReactShadowNode<*>>> = mutableListOf()
+
+    override fun createNativeModules(
+        reactContext: ReactApplicationContext
+    ): MutableList<NativeModule> = listOf(RNTimeZoneModule(reactContext)).toMutableList()
+}

--- a/Sandbox/ios/Sandbox.xcodeproj/project.pbxproj
+++ b/Sandbox/ios/Sandbox.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		6967379D2C98B63800574D33 /* RNTimeZoneModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 6967379B2C98B63800574D33 /* RNTimeZoneModule.m */; };
 		69E20DBC2C961C71002FC173 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 69E20DBB2C961C71002FC173 /* GoogleService-Info.plist */; };
 		69E20DBE2C967AC5002FC173 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 69E20DBD2C967AC5002FC173 /* PrivacyInfo.xcprivacy */; };
 		715F11AF1F28A2B5718724A3 /* Pods_Sandbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CABBCFCEE80BEC9CE96F205 /* Pods_Sandbox.framework */; };
@@ -43,6 +44,8 @@
 		3B4392A12AC88292D35C810B /* Pods-Sandbox.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sandbox.debug.xcconfig"; path = "Target Support Files/Pods-Sandbox/Pods-Sandbox.debug.xcconfig"; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-Sandbox.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sandbox.release.xcconfig"; path = "Target Support Files/Pods-Sandbox/Pods-Sandbox.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-Sandbox-SandboxTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sandbox-SandboxTests.debug.xcconfig"; path = "Target Support Files/Pods-Sandbox-SandboxTests/Pods-Sandbox-SandboxTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6967379A2C98B63800574D33 /* RNTimeZoneModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNTimeZoneModule.h; sourceTree = "<group>"; };
+		6967379B2C98B63800574D33 /* RNTimeZoneModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNTimeZoneModule.m; sourceTree = "<group>"; };
 		69746A632A00022E008B162A /* Sandbox.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = Sandbox.entitlements; path = Sandbox/Sandbox.entitlements; sourceTree = "<group>"; };
 		69E20DBB2C961C71002FC173 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		69E20DBD2C967AC5002FC173 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Sandbox/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -91,6 +94,7 @@
 		13B07FAE1A68108700A75B9A /* Sandbox */ = {
 			isa = PBXGroup;
 			children = (
+				6967379C2C98B63800574D33 /* TimeZoneModule */,
 				69E20DBD2C967AC5002FC173 /* PrivacyInfo.xcprivacy */,
 				69E20DBB2C961C71002FC173 /* GoogleService-Info.plist */,
 				69746A632A00022E008B162A /* Sandbox.entitlements */,
@@ -112,6 +116,16 @@
 				28753C94F354AB61E04229D9 /* Pods_Sandbox_SandboxTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6967379C2C98B63800574D33 /* TimeZoneModule */ = {
+			isa = PBXGroup;
+			children = (
+				6967379A2C98B63800574D33 /* RNTimeZoneModule.h */,
+				6967379B2C98B63800574D33 /* RNTimeZoneModule.m */,
+			);
+			name = TimeZoneModule;
+			path = Sandbox/TimeZoneModule;
 			sourceTree = "<group>";
 		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
@@ -436,6 +450,7 @@
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				6967379D2C98B63800574D33 /* RNTimeZoneModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -618,9 +633,12 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
-					" ${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
-					" ${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
-					" ${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD = "";
@@ -709,9 +727,12 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
-					" ${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
-					" ${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
-					" ${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD = "";

--- a/Sandbox/ios/Sandbox/TimeZoneModule/RNTimeZoneModule.h
+++ b/Sandbox/ios/Sandbox/TimeZoneModule/RNTimeZoneModule.h
@@ -1,0 +1,4 @@
+//  RNTimeZoneModule.h
+#import <React/RCTBridgeModule.h>
+@interface RNTimeZoneModule: NSObject <RCTBridgeModule>
+@end

--- a/Sandbox/ios/Sandbox/TimeZoneModule/RNTimeZoneModule.m
+++ b/Sandbox/ios/Sandbox/TimeZoneModule/RNTimeZoneModule.m
@@ -1,0 +1,21 @@
+#import "RNTimeZoneModule.h"
+#import <React/RCTLog.h>
+
+@implementation RNTimeZoneModule
+
+RCT_EXPORT_MODULE();
+
+RCT_REMAP_METHOD(getTimeZone,
+                 getTimeZoneWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  NSString *timeZoneName = [[NSTimeZone localTimeZone] name];
+  if (timeZoneName) {
+    resolve(timeZoneName);
+  } else {
+    NSError *error = [NSError errorWithDomain:@"RNTimeZoneError" code:500 userInfo:nil];
+    reject(@"no_timezone", @"Could not retrieve timezone", error);
+  }
+}
+
+@end


### PR DESCRIPTION
This module replaces the [react-native-localize's](https://github.com/zoontek/react-native-localize) `getTimeZone()` function, because `react-native-localize` has `isBlockingSynchronousMethod = true`, which doesn't permit us to use React Native Debugger, per the [React Native documentation](https://reactnative.dev/docs/native-modules-android?android-language=kotlin):

"You can pass isBlockingSynchronousMethod = true to a native method to mark it as a synchronous method.

At the moment, we do not recommend this, since calling methods synchronously can have strong performance penalties and introduce threading-related bugs to your native modules. Additionally, please note that if you choose to enable isBlockingSynchronousMethod, your app can no longer use the Google Chrome debugger. This is because synchronous methods require the JS VM to share memory with the app. For the Google Chrome debugger, React Native runs inside the JS VM in Google Chrome, and communicates asynchronously with the mobile devices via WebSockets."


